### PR TITLE
feat: bumps version to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2023-10-07
+
+### Changed
+
+- Replaces DockerHub source from deprecated "vault" to "hashicorp/vault"
+
 ## [0.1.7] - 2022-05-13
 
 ### Changed
@@ -63,7 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/jmgilman/dockertest-server/compare/v0.1.7...HEAD
+[unreleased]: https://github.com/jmgilman/dockertest-server/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/jmgilman/dockertest-server/releases/tag/v0.1.8
 [0.1.7]: https://github.com/jmgilman/dockertest-server/releases/tag/v0.1.7
 [0.1.6]: https://github.com/jmgilman/dockertest-server/releases/tag/v0.1.6
 [0.1.5]: https://github.com/jmgilman/dockertest-server/releases/tag/v0.1.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dockertest-server"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
 description = "A test framework built around dockertest for testing against server containers."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add `dockertest-server` as a dependency to your cargo.toml:
 
 ```toml
 [dev-dependencies]
-dockertest-server = "0.1.7"
+dockertest-server = "0.1.8"
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Add `dockertest-server` as a dependency to your cargo.toml:
 //! ```ignore
 //! [dev-dependencies]
-//! dockertest-server = "0.1.7"
+//! dockertest-server = "0.1.8"
 //! ```
 //!
 //! ## Usage

--- a/src/servers/hashi/vault.rs
+++ b/src/servers/hashi/vault.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use dockertest::{waitfor, Source};
 use std::collections::HashMap;
 
-const IMAGE: &str = "vault";
+const IMAGE: &str = "hashicorp/vault";
 const PORT: u32 = 8200;
 const LOG_MSG: &str = "Development mode should NOT be used in production installations!";
 const SOURCE: Source = Source::DockerHub;


### PR DESCRIPTION
Replaced [deprecated](https://hub.docker.com/_/vault) vault image repo with [official docker image repo](https://hub.docker.com/r/hashicorp/vault)
So we could use vault images newer than 1.13.3 in [vaultrs](https://github.com/jmgilman/vaultrs/) repo