### PR TITLE
fix: replace deprecated hashicorp images

### DIFF
--- a/src/servers/hashi/consul.rs
+++ b/src/servers/hashi/consul.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use dockertest::{waitfor, Source};
 use std::collections::HashMap;
 
-const IMAGE: &str = "consul";
+const IMAGE: &str = "hashicorp/consul";
 const PORT: u32 = 8500;
 const LOG_MSG: &str = "Synced node info";
 const SOURCE: Source = Source::DockerHub;

--- a/src/servers/hashi/vault.rs
+++ b/src/servers/hashi/vault.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use dockertest::{waitfor, Source};
 use std::collections::HashMap;
 
-const IMAGE: &str = "vault";
+const IMAGE: &str = "hashicorp/vault";
 const PORT: u32 = 8200;
 const LOG_MSG: &str = "Development mode should NOT be used in production installations!";
 const SOURCE: Source = Source::DockerHub;


### PR DESCRIPTION
The images `consul` and `vault` have been deprecated in place of `hashicorp/vault` and `hashicorp/consul` this only replace them with the new images path